### PR TITLE
Simple Fix to Allow Compilation On MSVC

### DIFF
--- a/compile.h
+++ b/compile.h
@@ -240,6 +240,8 @@ inline static void builder_compile_cc(size_t count, const char* filepaths[], con
 	const char* cc_command = "clang";
 #elif defined(__GNUC__)
 	const char* cc_command = "gcc";
+#elif defined(_MSC_VER)
+	const char* cc_command = 0;
 #endif
 	
 	// compile object files


### PR DESCRIPTION
When compiling with MSVC, `cc_command` doesn't isn't declared. This PR adds a declaration with a default value of 0. This function isn't called when compiling with MSVC, but it still blocks compiling `compile.c`

![image](https://user-images.githubusercontent.com/36315399/163528025-ecdb4176-87d2-4a39-b006-32656216c787.png)