### PR TITLE
Fix some bugs, add small improvements

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,6 +1,6 @@
 @echo off
 
-clang compile.c -DBUILD_RELEASE -o compile.exe
+clang compile.c -DRELEASE_BUILD -o compile.exe
 if ERRORLEVEL 1 exit /b 1
 
 compile

--- a/compile.h
+++ b/compile.h
@@ -200,8 +200,21 @@ inline static void builder_init() {
 	setvbuf(stdout, NULL, _IONBF, 0);
 	
 #if defined(_WIN32)
-	// sets environment vars for compiler
-	system("call vcvars64");
+	// sets environment vars for compiler, if not already set
+	{
+		// NOTE(bumbread): pretty sure this environment variable is a good
+		// indicator of vcvars present.
+		char *env = getenv("VSINSTALLDIR");
+		if(env == NULL) {
+			int vcvars_ret = system("call vcvars64");
+			if(vcvars_ret != 0) {
+				fprintf(stderr, "ERROR: vcvars64.bat wasn't found. "
+					   "Please add it shell PATH or run the build script in "
+					   "Visual Studio Developer's Command Prompt\n");
+				exit(69420);
+			}
+		}
+	}
 #endif
 	
 	create_dir_if_not_exists("build/");
@@ -223,7 +236,7 @@ inline static void builder_compile_msvc(size_t count, const char* filepaths[], c
 #   if defined(RELEASE_BUILD)
 	cmd_append("/Ox /WX /GS- /DNDEBUG ");
 #   else
-	cmd_append("/MTd /Od /WX /Zi /D_DEBUG /RTC1 ");
+	cmd_append("/MTd /Od /WX /Z7 /D_DEBUG /RTC1 ");
 #   endif
 	
 	for (size_t i = 0; i < count; i++) {

--- a/src/main_driver.c
+++ b/src/main_driver.c
@@ -613,7 +613,7 @@ static int parse_args(size_t arg_start, size_t arg_count, char** args) {
 			output_name = value;
 		} else if (strcmp(key, "target") == 0) {
 			bool matches = false;
-			for (size_t i = 0; i < TARGET_OPTION_COUNT; i++) {
+			if(value) for (size_t i = 0; i < TARGET_OPTION_COUNT; i++) {
 				if (strcmp(target_options[i].name, value) == 0) {
 					target_arch = target_options[i].arch;
 					target_system = target_options[i].system;
@@ -632,6 +632,10 @@ static int parse_args(size_t arg_start, size_t arg_count, char** args) {
 				return 1;
 			}
 		} else if (strcmp(key, "threads") == 0) {
+			if(!value) {
+				printf("thread count should be specified as an integer\n");
+				return 1;
+			}
 			int num;
 			int matches = sscanf(value, "%d", &num);
 			if (matches != 1) {


### PR DESCRIPTION
Changes:
1. If the user who is compiling Cuik already has vcvars set, vcvars won't need to be initialized again. Helps with extra error message like "vcvars not found" in case of Visual Studio Developer Prompt that doesn't keep vcvars in it's PATH by default.
2. If vcvars weren't found in PATH a nice error message is displayed telling the user to either add it to PATH or use the Visual Studio Develeoper Command Prompt.
3. /Z7 doesn't emit an extra pdb (that's not essential for normal debugging) also fuck visual studio
4. Fixed a case of UB on calling strcmp with NULL argument that would trigger a crash on Windows if the argument to an option is not specified.