### PR TITLE
tb: Windows fixes

### DIFF
--- a/tb/include/tb.h
+++ b/tb/include/tb.h
@@ -735,7 +735,7 @@ TB_API TB_External* tb_next_external(TB_External* e);
 
 // this is used JIT scenarios to tell the compiler what externals map to
 TB_API TB_ExternalType tb_extern_get_type(TB_External* e);
-TB_Global* tb_extern_transmute(TB_External* e, TB_DebugType* dbg_type, TB_Linkage linkage);
+TB_API TB_Global* tb_extern_transmute(TB_External* e, TB_DebugType* dbg_type, TB_Linkage linkage);
 
 TB_API TB_External* tb_extern_create(TB_Module* m, ptrdiff_t len, const char* name, TB_ExternalType type);
 

--- a/tb/include/tb_coff.h
+++ b/tb/include/tb_coff.h
@@ -313,7 +313,11 @@ size_t tb_coff_parse_symbol(TB_COFF_Parser* restrict parser, size_t i, TB_Object
         out_sym->name = (TB_Slice){ strlen((const char*) data), data };
     } else {
         // normal inplace string
-        size_t len = strlen((const char*) sym->short_name);
+        size_t len = 1;
+        const char* name = (const char*) sym->short_name;
+        while (len < 8 && name[len] != 0) {
+            len++;
+        }
         out_sym->name = (TB_Slice){ len, sym->short_name };
     }
 

--- a/tb/src/linker/linker.c
+++ b/tb/src/linker/linker.c
@@ -565,11 +565,11 @@ void tb__apply_module_relocs(TB_Linker* l, TB_Module* m, uint8_t* output) {
         if (func_out == NULL) continue;
 
         for (TB_SymbolPatch* patch = func_out->last_patch; patch; patch = patch->prev) {
+            TB_FunctionOutput* out_f = patch->source->output;
             _Atomic(int32_t)* dst = (_Atomic(int32_t)*) &output[text_piece_file + out_f->code_pos + patch->pos];
 
             int32_t p = 0;
             if (patch->target->tag == TB_SYMBOL_EXTERNAL) {
-                TB_FunctionOutput* out_f = patch->source->output;
                 size_t actual_pos = text_piece_rva + out_f->code_pos + patch->pos + 4;
 
                 ImportThunk* thunk = patch->target->address;
@@ -579,7 +579,6 @@ void tb__apply_module_relocs(TB_Linker* l, TB_Module* m, uint8_t* output) {
             } else if (patch->target->tag == TB_SYMBOL_FUNCTION) {
                 // internal patching has already handled this
             } else if (patch->target->tag == TB_SYMBOL_GLOBAL) {
-                TB_FunctionOutput* out_f = patch->source->output;
                 size_t actual_pos = text_piece_rva + out_f->code_pos + patch->pos + 4;
 
                 TB_Global* global = (TB_Global*) patch->target;


### PR DESCRIPTION
The interesting one is the short symbol parse in `tb_coff.h`. Found it when experimenting with linking the `__chkstk` function, a symbol name exactly 8 bytes long, incidentally. :)