### PR TITLE
fixes to build minivm on linux

### DIFF
--- a/common/buffer.h
+++ b/common/buffer.h
@@ -2,6 +2,8 @@
 #ifndef NL_BUFFER_H
 #define NL_BUFFER_H
 
+#include "stdarg.h"
+
 struct nl_buffer_t;
 typedef struct nl_buffer_t nl_buffer_t;
 

--- a/common/spall.h
+++ b/common/spall.h
@@ -381,7 +381,7 @@ SPALL_FN SPALL_FORCEINLINE bool spall_buffer_begin_args(SpallProfile *ctx, Spall
     return true;
 }
 
-SPALL_FN SPALL_FORCEINLINE bool spall_buffer_begin_ex(SpallProfile *ctx, SpallBuffer *wb, const char *name, signed long name_len, double when, uint32_t tid, uint32_t pid) {
+SPALL_FN bool spall_buffer_begin_ex(SpallProfile *ctx, SpallBuffer *wb, const char *name, signed long name_len, double when, uint32_t tid, uint32_t pid) {
     return spall_buffer_begin_args(ctx, wb, name, name_len, "", 0, when, tid, pid);
 }
 
@@ -389,7 +389,7 @@ SPALL_FN bool spall_buffer_begin(SpallProfile *ctx, SpallBuffer *wb, const char 
     return spall_buffer_begin_args(ctx, wb, name, name_len, "", 0, when, 0, 0);
 }
 
-SPALL_FN SPALL_FORCEINLINE bool spall_buffer_end_ex(SpallProfile *ctx, SpallBuffer *wb, double when, uint32_t tid, uint32_t pid) {
+SPALL_FN bool spall_buffer_end_ex(SpallProfile *ctx, SpallBuffer *wb, double when, uint32_t tid, uint32_t pid) {
 #ifdef SPALL_DEBUG
     if (!ctx) return false;
     if (!wb) return false;

--- a/tb/src/chaitin.c
+++ b/tb/src/chaitin.c
@@ -407,7 +407,7 @@ void tb__chaitin(Ctx* restrict ctx, TB_Arena* arena) {
 
             uint64_t mask = vreg->mask->mask[0];
             printf("v%d:\n", vreg_id);
-            printf("  => %#llx\n", mask);
+            printf("  => %#"PRIx64"\n", mask);
 
             int def_class = vreg->mask->class;
             FOR_N(j, 0, ra.ifg_stride) {
@@ -421,12 +421,12 @@ void tb__chaitin(Ctx* restrict ctx, TB_Arena* arena) {
                     int fixed = fixed_reg_mask(other->mask);
                     if (fixed >= 0) {
                         mask &= ~(1ull << fixed);
-                        printf("  => %#llx (neighbor precolored R%d)\n", mask, fixed);
+                        printf("  => %#"PRIx64" (neighbor precolored R%d)\n", mask, fixed);
                     } else {
                         int assigned = other->assigned;
                         if (assigned >= 0) {
                             mask &= ~(1ull << assigned);
-                            printf("  => %#llx (we can't be R%d)\n", mask, assigned);
+                            printf("  => %#"PRIx64" (we can't be R%d)\n", mask, assigned);
                         }
                     }
                 }

--- a/tb/src/lsra.c
+++ b/tb/src/lsra.c
@@ -1,6 +1,7 @@
 // Linear scan register allocator:
 //   https://ssw.jku.at/Research/Papers/Wimmer04Master/Wimmer04Master.pdf
 #include "codegen.h"
+#include <limits.h>
 
 #define FOREACH_SET(it, set) \
 FOR_N(_i, 0, ((set).capacity + 63) / 64) FOR_BIT(it, _i*64, (set).data[_i])

--- a/tb/src/opt/optimizer.c
+++ b/tb/src/opt/optimizer.c
@@ -449,13 +449,14 @@ static bool can_gvn(TB_Node* n) {
         case TB_SAFEPOINT_POLL:
         return false;
 
-        default:
-        int family = n->type / 0x100;
-        if (family == 0) {
-            return true;
-        } else {
-            assert(family >= 0 && family < TB_ARCH_MAX);
-            return tb_codegen_families[family].extra_bytes(n);
+        default: {
+            int family = n->type / 0x100;
+            if (family == 0) {
+                return true;
+            } else {
+                assert(family >= 0 && family < TB_ARCH_MAX);
+                return tb_codegen_families[family].extra_bytes(n);
+            }
         }
     }
 }
@@ -931,7 +932,7 @@ static void print_lattice(Lattice* l) {
                 printf("; zeros=%#"PRIx64", ones=%#"PRIx64, l->_int.known_zeros, l->_int.known_ones);
             }
             if (l->_int.widen) {
-                printf(", widen=%llu", l->_int.widen);
+                printf(", widen=%"PRIu64, l->_int.widen);
             }
             printf("]");
             break;

--- a/tb/src/opt/passes.h
+++ b/tb/src/opt/passes.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "../tb_internal.h"
 #include <arena_array.h>
+#include <limits.h>
 
 enum {
     INT_WIDEN_LIMIT = 3,
@@ -96,8 +97,8 @@ struct Lattice {
         double _f64;        // LATTICE_FLTCON64
     };
     union {
-        uint64_t alias[];
-        Lattice* elems[];
+        uint64_t alias[0];
+        Lattice* elems[0];
     };
 };
 

--- a/tb/src/opt/print_dumb.h
+++ b/tb/src/opt/print_dumb.h
@@ -47,7 +47,7 @@ void tb_print_dumb_node(Lattice** types, TB_Node* n) {
     } else if (n->type == TB_MACH_PROJ) {
         printf("%d ", TB_NODE_GET_EXTRA_T(n, TB_NodeMachProj)->index);
     } else if (n->type == TB_MEMBER_ACCESS) {
-        printf("%lld ", TB_NODE_GET_EXTRA_T(n, TB_NodeMember)->offset);
+        printf("%"PRIi64" ", TB_NODE_GET_EXTRA_T(n, TB_NodeMember)->offset);
     } else if (n->type == TB_STORE) {
         print_type(n->inputs[3]->dt);
         printf(" ");


### PR DESCRIPTION
This PR fixes the new-cg branch to do the following 4 things.

1. Use `stdarg.h` for the stdarg stuff in common/buffer.h
2. Remove two `SPALL_FORCEINLINE`s that break on linux
3. Use int formats in `inttypes.h` where needed.
4. Wrap `default/case` that decl's variables.
5. Use `the_type_t blah[0]` instead of `the_type_t name[]` for union of flexable array members.


Thanks for giving it a look.