### PR TITLE
Fix initial capacity of emitter

### DIFF
--- a/common/emitter.c
+++ b/common/emitter.c
@@ -7,7 +7,11 @@
 void* tb_out_reserve(TB_Emitter* o, size_t count) {
     if (o->count + count >= o->capacity) {
         if (o->capacity == 0) {
-            o->capacity = 64;
+            if (count < 64) {
+                o->capacity = 64;
+            } else {
+                o->capacity = count;
+            }
         } else {
             o->capacity += count;
             o->capacity *= 2;


### PR DESCRIPTION
When you use `tb_out_reserve` right away after emitter creation with byte count > 64, it will allocate only 64 bytes and set capacity of to 64.

In elf64.c file we see: 
```c
    TB_Emitter strtbl = { 0 };
    tb_out_reserve(&strtbl, 1024); // strtbl will have 64 capacity
    tb_out1b(&strtbl, 0);
```
with latter usage of tb_out_*_UNSAFE results in overwrite of random memory ...