### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ jobs:
     runs-on: windows-2022
     if: github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v3
-      - uses: seanmiddleditch/gha-setup-ninja@master
+      - uses: actions/checkout@v4
+      - uses: seanmiddleditch/gha-setup-ninja@v6
 
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: leafo/gh-actions-lua@v10
@@ -28,13 +28,13 @@ jobs:
         run: lua build.lua -shared -cuik -tb
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cuik-windows
           path: bin/cuik.exe
 
       - name: upload dll artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cuik-windows
           path: bin/cuik.dll
@@ -55,7 +55,7 @@ jobs:
         timeout-minutes: 10
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cuik-linux
           path: bin/cuik
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: seanmiddleditch/gha-setup-ninja@master
+      - uses: seanmiddleditch/gha-setup-ninja@v6
 
       - uses: ilammy/msvc-dev-cmd@v1
         if: runner.os == 'Windows'
@@ -128,7 +128,7 @@ jobs:
               sha: context.sha
             })
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
 
       - name: Bundle
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on: [pull_request, workflow_dispatch, push]
 jobs:
   build_win:
     runs-on: windows-2022
-    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
       - uses: seanmiddleditch/gha-setup-ninja@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
       - uses: seanmiddleditch/gha-setup-ninja@v6
 
       - uses: ilammy/msvc-dev-cmd@v1
-      - uses: leafo/gh-actions-lua@v10
+      - uses: leafo/gh-actions-lua@v11
         with:
-          luaVersion: "5.3.0"
+          luaVersion: "luajit"
 
       - name: Download Submodules
         run: git submodule update --init --recursive
@@ -44,8 +44,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: seanmiddleditch/gha-setup-ninja@master
 
+      - uses: leafo/gh-actions-lua@v11
+        with:
+          luaVersion: "luajit"
+
       - name: Download LLVM & Lua
-        run: sudo apt-get install llvm clang lld lua5.3
+        run: sudo apt-get install llvm clang lld
 
       - name: Download Submodules
         run: git submodule update --init --recursive
@@ -74,14 +78,13 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
         if: runner.os == 'Windows'
 
-      - uses: leafo/gh-actions-lua@v10
-        if: runner.os == 'Windows'
+      - uses: leafo/gh-actions-lua@v11
         with:
-          luaVersion: "5.3.0"
+          luaVersion: "luajit-2.1.0-beta3"
 
-      - name: Download LLVM & Lua
+      - name: Download LLVM
         if: runner.os == 'Linux'
-        run: sudo apt-get install llvm clang lld lua5.3
+        run: sudo apt-get install llvm clang lld
 
       - name: Download Submodules
         run: git submodule update --init --recursive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build Cuik DLL
         shell: cmd
         timeout-minutes: 10
-        run: lua build.lua -shared -cuik -tb
+        run: lua build.lua -x64 -a64 -shared -cuik -tb
 
       - name: upload artifacts
         uses: actions/upload-artifact@v4
@@ -38,6 +38,7 @@ jobs:
         with:
           name: cuik-windows
           path: bin/cuik.dll
+
   build_linux:
     runs-on: ubuntu-latest
     steps:
@@ -51,7 +52,7 @@ jobs:
         run: git submodule update --init --recursive
 
       - name: Build Cuik
-        run: lua build.lua -driver
+        run: lua build.lua -x64 -a64 -driver
         timeout-minutes: 10
 
       - name: upload artifacts
@@ -59,6 +60,7 @@ jobs:
         with:
           name: cuik-linux
           path: bin/cuik
+
   tb_unittests:
     strategy:
       matrix:
@@ -99,6 +101,7 @@ jobs:
       - name: Run TB unittests
         timeout-minutes: 5
         run: ./bin/tb_unittests
+
   release:
     runs-on: ubuntu-latest
     needs: [build_win, build_linux]

--- a/tb/aarch64/a64_gen.h
+++ b/tb/aarch64/a64_gen.h
@@ -70,9 +70,9 @@ static bool mach_is_subpat[512] = {
 #define R_POP(n, next)      (((n) << 16u) | (next))
 static void global_init(void) {
     static const uint32_t edges[] = {
-        (0)<<16 | (TB_ADD+1), R_PUSH(5),
         (0)<<16 | (TB_F32CONST+1), R_PUSH(1),
         (0)<<16 | (TB_F64CONST+1), R_PUSH(3),
+        (0)<<16 | (TB_ADD+1), R_PUSH(5),
         (1)<<16 | (0), 2,
         (2)<<16 | (TB_NULL+1), R_POP(2, 2),
         (3)<<16 | (0), 4,


### PR DESCRIPTION
The CI build failure was caused by the deprecation of v3 artifact actions, which includes download-artifact@v3 and checkout@v3. See https://github.com/orgs/community/discussions/142581 for details.

This fixes the versions of the GitHub actions so that the CI can pass. The seanmiddleditch/gha-setup-ninja action has been explicitly set to use @v6 version, since it's better for the thing to work than to break randomly. Well it's an archived repo, so like what's the difference anyway.